### PR TITLE
Transformation of double underscore to dot removed

### DIFF
--- a/elasticsearch_dsl/utils.py
+++ b/elasticsearch_dsl/utils.py
@@ -198,8 +198,6 @@ class DslBase(object):
     def __init__(self, **params):
         self._params = {}
         for pname, pvalue in iteritems(params):
-            if '__' in pname:
-                pname = pname.replace('__', '.')
             self._setattr(pname, pvalue)
 
     def _repr_params(self):

--- a/test_elasticsearch_dsl/test_query.py
+++ b/test_elasticsearch_dsl/test_query.py
@@ -183,11 +183,6 @@ def test_Q_constructs_query_by_name():
     assert isinstance(q, query.Match)
     assert {'f': 'value'} == q._params
 
-def test_Q_translates_double_underscore_to_dots_in_param_names():
-    q = query.Q('match', comment__author='honza')
-
-    assert {'comment.author': 'honza'} == q._params
-
 def test_Q_constructs_simple_query_from_dict():
     q = query.Q({'match': {'f': 'value'}})
 


### PR DESCRIPTION
Patch to issue https://github.com/elastic/elasticsearch-dsl-py/issues/28 not required in my project. It is conflicting with field names having double underscore __
